### PR TITLE
updated .exe name and changed dropbox download link to blank target

### DIFF
--- a/00-getting-started.md
+++ b/00-getting-started.md
@@ -32,7 +32,7 @@ minutes:
 * Note that "double-clicking" a zipped file on a windows machine sometimes results in a correctly unzipped set of files, other times, this is not successful. Try installing 7-Zip and use 7-Zip to extract all files from the zipped file to the desired directory.
 * Go to your newly created Open-Refine directory.
 * Launch Open Refine
-  * Windows: Click the google-refine.exe
+  * Windows: Click the openrefine.exe (or google-refine.exe if using an older version)
   * Mac: Drag icon into Applications folder and double-click it
   * Linux: Run ./refine
 * Note, this is a Java program that runs on your machine (not in the cloud). It runs inside the Firefox browser, but no web connection is needed.

--- a/01-working-with-openrefine.md
+++ b/01-working-with-openrefine.md
@@ -25,8 +25,7 @@ Note the file types Open Refine handles: TSV, CSF, *SV, Excel (.xls .xlsx), JSON
 
 In this first step, we'll browse our computer to the sample data file for this lesson. In this case, I've modified the Portal_rodents csv file. I added several columns: scientificName, locality, county, state, country and I generated several more columns in the lesson itself (JSON, decimalLatitude, decimalLongitude). Data in locality, county, country, JSON, decimalLatitude and decimalLongitude are contrived and are in no way related to the original dataset. When doing this demo, the columns: JSON, decimalLatitude, decimalLongitude can be deleted, and then recreated if time, with a call to a locality service, and subsequent parsing of the JSON data returned by the service.
 
-If you haven't already, download the data from:  
-[https://www.dropbox.com/s/kbb4k00eanm19lg/Portal_rodents_19772002_scinameUUIDs.csv?dl=0](https://www.dropbox.com/s/kbb4k00eanm19lg/Portal_rodents_19772002_scinameUUIDs.csv?dl=0)
+If you haven't already, download the data from: <a href="https://www.dropbox.com/s/kbb4k00eanm19lg/Portal_rodents_19772002_scinameUUIDs.csv?dl=0" target="_blank">https://www.dropbox.com/s/kbb4k00eanm19lg/Portal_rodents_19772002_scinameUUIDs.csv?dl=0</a> 
 
 
 **Once Refine is open, you'll be asked if you want to Create, Open, or Import a Project.**

--- a/01-working-with-openrefine.md
+++ b/01-working-with-openrefine.md
@@ -19,7 +19,7 @@ minutes:
 
 ## Creating a Project
 
-Start the program. (Double-click on the google-refine.exe file. Java services will start on your machine, and Refine will open in your Firefox browser).
+Start the program. (Double-click on the openrefine.exe file (or google-refine.exe if using an older version). Java services will start on your machine, and Refine will open in your Firefox browser).
 
 Note the file types Open Refine handles: TSV, CSF, *SV, Excel (.xls .xlsx), JSON, XML, RDF as XML, Google Data documents. Support for other formats can be added with Google Refine extensions.
 


### PR DESCRIPTION
I was reviewing these for an upcoming workshop and noticed a few things
1. The file name for firing this up from windows is now openrefine.exe not google-refine.exe.
2. The link for dropbox opened in the same window as the lesson.  I kept closing that down after and had to relocate the lesson.  I changed it to open in a new tab.

Hope these are useful changes!
