### PR TITLE
Fix typos and add lesson organization

### DIFF
--- a/_episodes/05-save-export.md
+++ b/_episodes/05-save-export.md
@@ -42,16 +42,18 @@ You can also export a project, for instance if you wanted to send it to someone 
 
 ## Exporting Cleaned Data 
 
-Save your work when you are done by exporting it in the desire format. Save your files with meaningful names, no spaces. Refine does not change your original dataset (hooray!).
+Save your work when you are done by exporting it in the desired format. Save your files with meaningful names, no spaces. Refine does not change your original dataset (hooray!).
 
 
->  - Go to 'Export' in the top right. Click on the file type you want to export the data in. 'Tab-separated values' or 'Comma-separated values' would be good choices. 
+>  - Go to 'Export' in the top right. Click on the file type you want to export the data in. 'Tab-separated values' (TSV) or 'Comma-separated values' (CSV) would be good choices. 
 
 
 That file will get
-exported to your default Download directory. That file can then be eaily opened in a 
+exported to your default Download directory. That file can then be opened in a 
 spreadsheet program
-or imported into programs like R or Python.
+or imported into programs like R or Python, which we'll be discussing later in our workshop. 
+Remember from our lesson on Spreadsheets that using widely-supported, 
+non-proprietary file formats like TSV or CSV improves the ability of yourself and others to use your data. 
 
 
 Previous: [Scripts](04-scripts/) | Next: [OpenRefine Resources](07-resources/)


### PR DESCRIPTION
Add references back to previously discussed concepts and forward to content on R or Python. 

Addresses  https://github.com/datacarpentry/OpenRefine-ecology-lesson/issues/81 except for ""meaningful names, no spaces" --> give an example of a "meaningful name" and possibly explain why not to use spaces in file names (as an aside, file naming conventions is an important topic that we don't go into as far as I've seen)"