### PR TITLE
Correct punctuation

### DIFF
--- a/_episodes/02-filter-exclude-sort_Correct_Punctuation.md
+++ b/_episodes/02-filter-exclude-sort_Correct_Punctuation.md
@@ -95,7 +95,7 @@ If you try to re-sort a column that you have already used, the drop-down menu ch
 {: .challenge}
 
 
-### Sorting by multiple columns.
+### Sorting by multiple columns
 
 You can sort by multiple columns by performing sort on additional columns. The sort will depend on the order in which you select columns to sort. To restart the sorting process with a particular column, check the `sort by this column alone` box in the `Sort` pop-up menu.
 


### PR DESCRIPTION
Correct punctuation in Ecology Lesson: Filtering and Sorting with OpenRefine.  Change ###Sorting by multiple columns. to ###Sorting by multiple columns (therefore removing the extraneous period at the end).

Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
