### PR TITLE
update openrefine reference links to new User Manual

### DIFF
--- a/_episodes/00-getting-started.md
+++ b/_episodes/00-getting-started.md
@@ -44,7 +44,7 @@ The following setup is necessary before we can get started (instructions [here](
 
 Do you need help with any of the following?
 
-- Download and install software from <http://openrefine.org/download.html>
+- Download and install software from <https://openrefine.org/download.html>
 - Download this [data file](https://ndownloader.figshare.com/files/7823341) and save to your desktop
 - Launch OpenRefine in Mozilla Firefox or Google Chrome
 - If after installation and running OpenRefine, it does not automatically open for you, point your browser at <http://127.0.0.1:3333/> or <http://localhost:3333/> to launch the program.
@@ -66,15 +66,15 @@ It can help you:
 - Save a set of data cleaning steps to replay on multiple files
 
 
-OpenRefine is a powerful, free and open source tool with a large growing community of practice. More help can be found at <http://openrefine.org>.
+OpenRefine is a powerful, free and open source tool with a large growing community of practice. More help can be found at <https://openrefine.org>.
 
 
 
 ## Basics of OpenRefine
 
-You can find out a lot more about OpenRefine at [http://openrefine.org](http://openrefine.org) and check out some great [introductory videos](https://www.youtube.com/channel/UCqwSVsJ8CWD9pQUZDbJC1ew). There is a [Google Group](https://groups.google.com/forum/#!forum/openrefine) that can answer a lot of beginner questions and problems. OpenRefine [recipes](https://github.com/OpenRefine/OpenRefine/wiki/Recipes), scripts, projects, and extensions are available too, where you can find and copy them into your OpenRefine instance to run on your dataset.
+You can find out a lot more about OpenRefine at <https://openrefine.org> and check out some great [introductory videos](https://www.youtube.com/channel/UCqwSVsJ8CWD9pQUZDbJC1ew). There is a [Google Group](https://groups.google.com/g/openrefine) that can answer a lot of beginner questions and problems. OpenRefine [recipes](https://github.com/OpenRefine/OpenRefine/wiki/Recipes), scripts, projects, and extensions are available too, where you can find and copy them into your OpenRefine instance to run on your dataset.
 
-The OpenRefine GitHub wiki page has a [reference](https://github.com/OpenRefine/OpenRefine/wiki/GREL-Functions) of the General Refine Expression Language (GREL).
+The OpenRefine user manual provides a [reference for the General Refine Expression Language (GREL)](https://docs.openrefine.org/manual/grelfunctions).
 
 ## Features
 

--- a/_episodes/01-working-with-openrefine.md
+++ b/_episodes/01-working-with-openrefine.md
@@ -26,7 +26,7 @@ Start the program. Double-click on the openrefine.exe file (or google-refine.exe
 
 Launch OpenRefine (see [Getting Started with OpenRefine](http://www.datacarpentry.org/OpenRefine-ecology-lesson/00-getting-started/)).
 
-OpenRefine can import a variety of file types, including tab separated (`tsv`), comma separated (`csv`), Excel (`xls`, `xlsx`), JSON, XML, RDF as XML, and Google Spreadsheets. See the [OpenRefine Importers page](https://github.com/OpenRefine/OpenRefine/wiki/Importers) for more information.
+OpenRefine can import a variety of file types, including tab separated (`tsv`), comma separated (`csv`), Excel (`xls`, `xlsx`), JSON, XML, RDF as XML, and Google Spreadsheets. See the [OpenRefine Create a Project by Importing Data page](https://docs.openrefine.org/manual/starting/#create-a-project-by-importing-data) for more information.
 
 In this first step, we'll browse our computer to the sample data file for this lesson. In this case, we modified the `Portal_rodents` CSV file, adding several columns: `scientificName`, `locality`, `county`, `state`, `country` and generating several more columns in the lesson itself (`JSON`, `decimalLatitude`, `decimalLongitude`). Data in `locality`, `county`, `country`, `JSON`, `decimalLatitude` and `decimalLongitude` are contrived and are in no way related to the original dataset. 
 
@@ -74,7 +74,7 @@ along with a number representing how many times that value occurs in the column.
 {: .solution}
 
 > ## More on Facets
-> [OpenRefine Wiki: Faceting](https://github.com/OpenRefine/OpenRefine/wiki/Faceting)
+> [OpenRefine Manual: Facets](https://docs.openrefine.org/manual/facets)
 > 
 > As well as 'Text facets' OpenRefine also supports a range of other types of facet. These include:
 > 

--- a/_episodes/06-resources.md
+++ b/_episodes/06-resources.md
@@ -20,7 +20,7 @@ OpenRefine is more than a simple data cleaning tool. People are using it for all
 OpenRefine has its own web site with documentation and a book:
 
 * [OpenRefine web site](http://openrefine.org/)
-* [OpenRefine Documentation for Users (Wiki site)](https://github.com/OpenRefine/OpenRefine/wiki/Documentation-For-Users)
+* [OpenRefine User Manual](https://docs.openrefine.org/) (the previous [OpenRefine Wiki](https://github.com/OpenRefine/OpenRefine/wiki) is being phased out)
 * [Using OpenRefine](http://www.worldcat.org/title/using-openrefine-the-essential-openrefine-guide-that-takes-you-from-data-analysis-and-error-fixing-to-linking-your-dataset-to-the-web/oclc/889271264) book by Ruben Verborgh, Max De Wilde and Aniket Sawant
 * [OpenRefine history from Wikipedia](https://en.wikipedia.org/wiki/OpenRefine)
 

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -39,7 +39,7 @@ OpenRefine supports faceted browsing as a mechanism for
 
 Typically, you create a facet on a particular column. The facet summarizes the cells in that column to give you a big picture of that column, and allows you to filter to some subset of rows for which their cells in that column satisfy some constraint. That's a bit abstract, so let's jump into some examples.
 
-[More on faceting](https://github.com/OpenRefine/OpenRefine/wiki/Faceting)
+[More on faceting](https://docs.openrefine.org/manual/facets/)
 
   - Scroll over to the scientificName column
   - Click the down arrow and choose Facet > Text facet


### PR DESCRIPTION
This PR updates links to OpenRefine reference from the old Wiki to the new docs "User Manual" site, https://docs.openrefine.org/
Refine is phasing out the wiki, so the User Manual should be the preferred reference. It slightly changes wording in link text to reflect the update. 

