### PR TITLE
Update 01-working-with-openrefine.md

### DIFF
--- a/_episodes/01-working-with-openrefine.md
+++ b/_episodes/01-working-with-openrefine.md
@@ -187,7 +187,7 @@ Important: If you skip this step, your solutions for later exercises will not be
 
 ## Trim Leading and Trailing Whitespace
 
-Words with spaces at the beginning or end are particularly hard for we humans to tell from strings without, but the blank characters will make a difference to the computer. We usually want to remove these. OpenRefine provides a tool to remove blank characters from the beginning and end of any entries that have them.
+Words with spaces at the beginning or end are particularly hard for we humans to tell from strings without, but the blank characters will make a difference to the computer. We usually want to remove these. OpenRefine provides a tool to remove blank characters from the beginning and end of any entries that have them. This tool is default when you import your dataset. 
 
 
 1. In the header for the column `scientificName`, choose `Edit cells` > `Common transforms` > `Trim leading and trailing whitespace`.


### PR DESCRIPTION
OpenRefine now defaults to trimming leading/trailing whitespace upon import. In the Split section #6 and the solution will need to be modified. I just ran through and there was no cols called scientificName 3 and scientificName 4 because of the trimming. In addition the Trim Leading ... section exercise needs to be modified because the results will be 0 cells modified. 
I only added a sentence to Trim because I'm not sure how to handle this. It requires some major work.

Please delete the text below before submitting your contribution.

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.  

---
