### PR TITLE
Fix "Clustering Methods in-depth URL"

### DIFF
--- a/_episodes/03-transforming-data.md
+++ b/_episodes/03-transforming-data.md
@@ -110,7 +110,7 @@ In the `scientificName` text facet box - click the `Cluster` button.
 your solutions for later exercises will not be the same as shown in those exercise solutions.
 
 > ## Clustering Documentation
-> Full documentation on clustering can be found at the [OpenRefine Clustering Methods In-depth](https://docs.openrefine.org/next/technical-reference/clustering-in-depth) page.
+> Full documentation on clustering can be found at the [OpenRefine Clustering Methods In-depth](https://openrefine.org/docs/technical-reference/clustering-in-depth) page.
 {: .callout}
 ## Data splitting
 


### PR DESCRIPTION
The URL for the Clustering Methods page of the OpenRefine documentation is broken/outdated/incorrect. Replaced here with the current link.