### PR TITLE
Update links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-## Contributing
+# Contributing
 
 [The Carpentries][cp-site] ([Software Carpentry][swc-site], [Data
 Carpentry][dc-site], and [Library Carpentry][lc-site]) are open source
@@ -6,7 +6,7 @@ projects, and we welcome contributions of all kinds: new lessons, fixes to
 existing material, bug reports, and reviews of proposed changes are all
 welcome.
 
-### Contributor Agreement
+## Contributor Agreement
 
 By contributing, you agree that we may redistribute your work under [our
 license](LICENSE.md). In exchange, we will address your issues and/or assess
@@ -14,7 +14,7 @@ your change proposal as promptly as we can, and help you become a member of our
 community. Everyone involved in [The Carpentries][cp-site] agrees to abide by
 our [code of conduct](CODE_OF_CONDUCT.md).
 
-### How to Contribute
+## How to Contribute
 
 The easiest way to get started is to file an issue to tell us about a spelling
 mistake, some awkward wording, or a factual error. This is a good way to
@@ -36,20 +36,20 @@ introduce yourself and to meet some of our community members.
 Note: if you want to build the website locally, please refer to [The Workbench
 documentation][template-doc].
 
-### Where to Contribute
+## Where to Contribute
 
 1. If you wish to change this lesson, add issues and pull requests here.
 2. If you wish to change the template used for workshop websites, please refer
    to [The Workbench documentation][template-doc].
 
 
-### What to Contribute
+## What to Contribute
 
 There are many ways to contribute, from writing new exercises and improving
 existing ones to updating or filling in the documentation and submitting [bug
 reports][issues] about things that do not work, are not clear, or are missing.
 If you are looking for ideas, please see [the list of issues for this
-repository][repo], or the issues for [Data Carpentry][dc-issues], [Library
+repository][repo-issues], or the issues for [Data Carpentry][dc-issues], [Library
 Carpentry][lc-issues], and [Software Carpentry][swc-issues] projects.
 
 Comments on issues and reviews of pull requests are just as welcome: we are
@@ -58,7 +58,7 @@ are particularly valuable**: it's easy for people who have been using these
 lessons for a while to forget how impenetrable some of this material can be, so
 fresh eyes are always welcome.
 
-### What *Not* to Contribute
+## What *Not* to Contribute
 
 Our lessons already contain more material than we can cover in a typical
 workshop, so we are usually *not* looking for more concepts or tools to add to
@@ -72,7 +72,7 @@ platform. Our workshops typically contain a mixture of Windows, macOS, and
 Linux users; in order to be usable, our lessons must run equally well on all
 three.
 
-### Using GitHub
+## Using GitHub
 
 If you choose to contribute via GitHub, you may want to look at [How to
 Contribute to an Open Source Project on GitHub][how-contribute]. In brief, we
@@ -92,7 +92,7 @@ Each lesson has a team of maintainers who review issues and pull requests or
 encourage others to do so. The maintainers are community volunteers, and have
 final say over what gets merged into the lesson.
 
-### Other Resources
+## Other Resources
 
 The Carpentries is a global organisation with volunteers and learners all over
 the world. We share values of inclusivity and a passion for sharing knowledge,
@@ -101,7 +101,8 @@ community listed at <https://carpentries.org/connect/> including via social
 media, slack, newsletters, and email lists. You can also [reach us by
 email][contact].
 
-[repo]: https://example.com/FIXME
+[repo]: https://github.com/datacarpentry/OpenRefine-ecology-lesson/
+[repo-issues]: https://github.com/datacarpentry/OpenRefine-ecology-lesson/issues
 [contact]: mailto:team@carpentries.org
 [cp-site]: https://carpentries.org/
 [dc-issues]: https://github.com/issues?q=user%3Adatacarpentry
@@ -111,7 +112,7 @@ email][contact].
 [github]: https://github.com
 [github-flow]: https://guides.github.com/introduction/flow/
 [github-join]: https://github.com/join
-[how-contribute]: https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
+[how-contribute]: https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github
 [issues]: https://carpentries.org/help-wanted-issues/
 [lc-issues]: https://github.com/issues?q=user%3ALibraryCarpentry
 [swc-issues]: https://github.com/issues?q=user%3Aswcarpentry


### PR DESCRIPTION
This fixes #294 by replacing the placeholder link, updating the egghead.io link and additionally adjusting the 'list of issues in this repository' link to actually point to the repo's issues.