### PR TITLE
Remove reference to sorting column values as numbers

### DIFF
--- a/episodes/03-exploring-data.md
+++ b/episodes/03-exploring-data.md
@@ -79,7 +79,7 @@ Facets are intended to group together common values and OpenRefine limits the nu
 
 ### Exploring numeric columns
 
-When a table is imported into OpenRefine, all columns are treated as having text values. We saw earlier how we can sort column values as numbers, but this does not change the cells in a column from text to numbers. Rather, this interprets the values as numbers for the purposes of sorting but keeps the underlying data type as is. We can, however, transform columns to other data types (e.g. number or date) using the `Edit cells` > `Common transforms` feature. Here we will experiment changing columns to numbers and see what additional capabilities that grants us.
+When a table is imported into OpenRefine, all columns are treated as having text values. We can transform columns to other data types (e.g. number or date) using the `Edit cells` > `Common transforms` feature. Here we will experiment changing columns to numbers and see what additional capabilities that grants us.
 
 #### Numeric facet
 


### PR DESCRIPTION
The "exploring numeric columns" section contained the following sentence: "We saw earlier how we can sort column values as numbers, but this does not change the cells in a column from text to numbers. Rather, this interprets the values as numbers for the purposes of sorting but keeps the underlying data type as is"

This episode has covered sorting facet values, but not column values, so this sentence does not make sense here and should be removed to avoid learner confusion.