### PR TITLE
Fix 'Text filters' section

### DIFF
--- a/episodes/05-filter-exclude-sort.md
+++ b/episodes/05-filter-exclude-sort.md
@@ -42,7 +42,7 @@ Click on `Reset` at the top-right of the facet before continuing to the next ste
 
 ### Text filters
 
-One way to filter data is to create a text filter on a column. Close all facets you may have created previously and reinstate the text facet on the `scientificName` column.
+One way to filter data is to create a text filter on a column. Close all facets you may have created previously.
 
 1. Click the down arrow next to `scientificName` > `Text filter`. A `scientificName` filter will appear on the left margin below the text facet.
 


### PR DESCRIPTION
The sentence introducing this section ended with the clause "and reinstate the text facet on the `scientificName` column", but the exercise that follows expects this facet to be closed. I removed this part of the sentence to make the exercise flow more logically from the preceding text.